### PR TITLE
Added tracking of unopened chests.

### DIFF
--- a/main.js
+++ b/main.js
@@ -197,6 +197,41 @@ setInterval(function () {
 }, 205);
 
 
+let chestSightings = [];
+
+setInterval(function() {
+  for (let c in parent.chests) {
+    chestSightings[c] = chestSightings[c] ? chestSightings[c] + 1 : 1;
+    if (chestSightings[c] == 10)
+      chest_log(c);
+  }
+}, 1000);
+
+function openLoggedChests(str)
+{
+  // Chest identifiers are currently exactly 30 alphanumeric chars long.
+  let chestsToOpen = str.replace(/.*([A-z0-9]{30})/g, "$1").split("\n");
+
+  let chestIndex = 0;
+
+  let interval = setInterval(function(){
+    if (character.esize < 8)
+      return;
+
+    let id = chestsToOpen[chestIndex];
+
+    game_log("Opening " + id);
+    parent.socket.emit("open_chest", {
+          id: id
+      });
+
+    // This leaves an off-by-one error, but the "undefined" printout is actually useful.
+    if (chestIndex >= chestsToOpen.length)
+      clearInterval(interval);
+    chestIndex += 1;
+  }, 500);
+}
+parent.openLoggedChests = openLoggedChests;
 
 /*
 


### PR DESCRIPTION
This postpones the need for better inventory management code.

If a chest remains unopened for 10 seconds, its id is logged to file. This allows it to survive client reloads and worse (without having to fiddle with local storage).
The openLoggedChests function takes the contents of such a file (easily pasted between backticks) and opens these logged chests over time. It pauses when the character has insufficient inventory (well, probably - there doesn't seem to be a way to get chest contents from id if the chest is no longer loaded in the client) and stops once done with all logged chests.

Chest appear to not be "garbage collected" by the goblin in Wizard's Crib unless the character is offline for a while. This makes it quite safe (loot-wise) to have your characters running unsupervised for long periods of time.