### PR TITLE
Add more reliable version of is_transporting.

### DIFF
--- a/Towns.js
+++ b/Towns.js
@@ -38,3 +38,33 @@ function in_town(entity) {
     }
     return false;
 }
+
+
+// character.c.town is just unreliable (tends to be cleared too early)
+const TOWN_END_MARGIN_MS = 500;
+const TOWN_END_HELPER_INTERVAL = 200;
+
+let townEnd = null;
+
+setInterval(function () {
+    if (character.c.town && character.c.town.ms < 1.5 * TOWN_END_HELPER_INTERVAL)
+        townEnd = new Date(new Date().getTime() + character.c.town.ms + TOWN_END_MARGIN_MS);
+}, TOWN_END_HELPER_INTERVAL);
+
+function wasIRecentlyTowning() {
+    if (!townEnd)
+        return false;
+    if (new Date() < townEnd)
+        return true;
+    // townEnd is in the past.
+    townEnd = null;
+    return false;
+}
+
+function isTransportingFixed(entity) {
+    if (is_transporting(entity))
+        return true;
+    if (entity.me && wasIRecentlyTowning())
+        return true;
+    return false;
+}

--- a/main.js
+++ b/main.js
@@ -133,7 +133,7 @@ setInterval(function () {
     loot();
 
     if (!attack_mode || character.rip) return;
-    if (is_moving(character) || is_transporting(character)) return;
+    if (is_moving(character) || isTransportingFixed(character)) return;
     if (in_town(character)) return;
 
     let targets = targetChoice({ min_xp: 1, max_att: 230, min_att: 10, max_targets: c("max_targets", 1) });


### PR DESCRIPTION
I have no idea how is_transporting is broken, but it is. It usually gets cleared too early and causes characters to do things they shouldn't do while teleporting to town (like attacking).

This version is pretty much a kludge (and really ugly) but the characters now actually sit tight while teleporting to town